### PR TITLE
Add spool usage dialog to material slots

### DIFF
--- a/src/components/printwatch-card.js
+++ b/src/components/printwatch-card.js
@@ -15,7 +15,8 @@ class PrintWatchCard extends LitElement {
       config: { type: Object },
       _cameraUpdateInterval: { type: Number },
       _dialogConfig: { state: true },
-      _confirmDialog: { state: true }
+      _confirmDialog: { state: true },
+      _spoolDialog: { state: true }
     };
   }
 
@@ -30,6 +31,7 @@ class PrintWatchCard extends LitElement {
     this._ext_cameraUpdateInterval = DEFAULT_EX_CAMERA_REFRESH_RATE;
     this._dialogConfig = { open: false };
     this._confirmDialog = { open: false };
+    this._spoolDialog = { open: false };
     this.formatters = {
       formatDuration,
       formatEndTime
@@ -146,6 +148,21 @@ class PrintWatchCard extends LitElement {
     this.requestUpdate();
   }
 
+  handleSpoolUsageDialog(slot) {
+    if (!slot?.spool_id) return;
+
+    this._spoolDialog = {
+      open: true,
+      spoolId: slot.spool_id,
+      title: localize.t('dialogs.use_filament.title'),
+      onClose: () => {
+        this._spoolDialog = { open: false };
+        this.requestUpdate();
+      }
+    };
+    this.requestUpdate();
+  }
+
   render() {
     if (!this.hass || !this.config) {
       return html``;
@@ -183,9 +200,11 @@ class PrintWatchCard extends LitElement {
       cameraProps,
       dialogConfig: this._dialogConfig,
       confirmDialog: this._confirmDialog,
+      spoolDialog: this._spoolDialog,
       setDialogConfig,
       handlePauseDialog: () => this.handlePauseDialog(),
       handleStopDialog: () => this.handleStopDialog(),
+      handleSpoolDialog: (slot) => this.handleSpoolUsageDialog(slot)
     });
   }
 

--- a/src/styles/card-styles.js
+++ b/src/styles/card-styles.js
@@ -359,6 +359,18 @@ export const cardStyles = css`
   align-items: center;
   gap: 8px;
   text-align: center;
+  cursor: pointer;
+  padding: 12px;
+  border-radius: 12px;
+  transition: background-color 0.2s ease;
+  -webkit-tap-highlight-color: transparent;
+}
+.material-slot:hover {
+  background-color: var(--secondary-background-color);
+}
+.material-slot:active {
+  background-color: var(--primary-color);
+  opacity: 0.8;
 }
   .material-circle-wrapper {
     position: relative;

--- a/src/templates/card-template.js
+++ b/src/templates/card-template.js
@@ -7,6 +7,7 @@ import { temperatureDisplayTemplate } from './components/temperature-display';
 import { materialSlotsTemplate } from './components/material-slots';
 import { temperatureDialogTemplate } from './components/temperature-controls';
 import { confirmDialogTemplate } from './components/confirm-dialog';
+import { spoolUsageDialogTemplate } from './components/spool-usage-dialog';
 
 export const cardTemplate = (context) => {
   const { 
@@ -19,9 +20,11 @@ export const cardTemplate = (context) => {
     formatters,
     dialogConfig,
     confirmDialog,
+    spoolDialog,
     setDialogConfig,
     handlePauseDialog,
-    handleStopDialog
+    handleStopDialog,
+    handleSpoolDialog
   } = context;
 
   if (!entities || !hass) return html``;
@@ -46,8 +49,9 @@ export const cardTemplate = (context) => {
         onImageError: context.handleImageError
       })}
       ${temperatureDisplayTemplate(entities, hass, dialogConfig, setDialogConfig)}
-      ${materialSlotsTemplate(amsSlots)}
+      ${materialSlotsTemplate(amsSlots, handleSpoolDialog)}
       ${temperatureDialogTemplate(dialogConfig, hass)}
+      ${spoolUsageDialogTemplate(spoolDialog, hass)}
       ${confirmDialogTemplate(confirmDialog)}
     </div>
   `;

--- a/src/templates/components/material-slots.js
+++ b/src/templates/components/material-slots.js
@@ -1,15 +1,15 @@
 import { html } from 'lit';
 import { localize } from '../../utils/localize';
 
-export const materialSlotsTemplate = (slots) => html`
+export const materialSlotsTemplate = (slots, onClick) => html`
   <div class="materials">
-    ${slots.map(slot => {
+    ${slots.map((slot, index) => {
       const percent = 100 * (1 - (slot.remaining_percent ?? 0));
       const baseColor = slot.color || '#E0E0E0';
       // Clip top 'percent%' of the fill only
       const clipInset = `inset(${percent}% 0 0 0)`;
       return html`
-        <div class="material-slot">
+        <div class="material-slot" @click=${() => onClick?.(slot, index)}>
           <div class="material-circle-wrapper">
             <!-- Border layer: full circle -->
             <div

--- a/src/templates/components/spool-usage-dialog.js
+++ b/src/templates/components/spool-usage-dialog.js
@@ -1,0 +1,51 @@
+import { html } from 'lit';
+import { localize } from '../../utils/localize';
+
+export const spoolUsageDialogTemplate = (dialogConfig, hass) => {
+  if (!dialogConfig?.open) return html``;
+
+  const handleSubmit = () => {
+    const dialog = document.getElementById('spoolUsageDialog');
+    const input = dialog?.querySelector('ha-textfield');
+    const value = input ? parseFloat(input.value) : null;
+    if (!dialogConfig.spoolId || value === null || isNaN(value)) return;
+
+    hass.callService('spoolman', 'use_spool_filament', {
+      id: dialogConfig.spoolId,
+      use_weight: value
+    }).then(() => dialogConfig.onClose()).catch(err => {
+      console.error('Error using filament:', err);
+    });
+  };
+
+  return html`
+    <ha-dialog
+      open
+      id="spoolUsageDialog"
+      @closed=${dialogConfig.onClose}
+      .heading=${dialogConfig.title}
+    >
+      <div class="dialog-content">
+        <ha-textfield
+          label=${localize.t('materials.enter_weight')}
+          type="number"
+          class="temp-input"
+        ></ha-textfield>
+      </div>
+      <mwc-button
+        slot="secondaryAction"
+        dialogAction="close"
+        class="cancel-button"
+      >
+        ${localize.t('controls.cancel')}
+      </mwc-button>
+      <mwc-button
+        slot="primaryAction"
+        @click=${handleSubmit}
+        class="save-button"
+      >
+        ${localize.t('controls.save')}
+      </mwc-button>
+    </ha-dialog>
+  `;
+};

--- a/src/translations/de.json
+++ b/src/translations/de.json
@@ -52,12 +52,17 @@
             "title": "Stopp bestätigen",
             "message": "Möchten Sie den aktuellen Druck wirklich stoppen? Diese Aktion kann nicht rückgängig gemacht werden.",
             "confirm": "Druck stoppen"
+          },
+          "use_filament": {
+            "title": "Filament verwenden",
+            "confirm": "Bestätigen"
           }
         },
         "materials": {
           "empty": "Leer",
           "unknown": "Unbekannt",
-          "external_spool": "Externe Spule"
+          "external_spool": "Externe Spule",
+          "enter_weight": "Verbrauchtes Gewicht (g)"
         }
       }
     }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -73,12 +73,17 @@
             "title": "Confirm Stop",
             "message": "Are you sure you want to stop the current print? This action cannot be undone.",
             "confirm": "Stop Print"
+          },
+          "use_filament": {
+            "title": "Use Filament",
+            "confirm": "Confirm"
           }
         },
         "materials": {
           "empty": "Empty",
           "unknown": "Unknown",
-          "external_spool": "External Spool"
+          "external_spool": "External Spool",
+          "enter_weight": "Used weight (g)"
         }
       }
     }

--- a/src/utils/state-helpers.js
+++ b/src/utils/state-helpers.js
@@ -99,7 +99,7 @@ export const getAmsSlots = (hass, config) => {
     }
   });
 
-  // Attach remainingWeight from spoolmanSensors
+  // Attach remainingWeight and spoolId from spoolmanSensors
   processedSlots.forEach((slot, idx) => {
     const sensorObj = spoolmanSensors[idx];
     if (sensorObj) {
@@ -108,6 +108,9 @@ export const getAmsSlots = (hass, config) => {
       if (!isNaN(weight)) {
         slot.weight = weight;
         slot.remaining_percent = remaining_percent;
+      }
+      if (sensorObj.attributes?.id !== undefined) {
+        slot.spool_id = sensorObj.attributes.id;
       }
     }
   });


### PR DESCRIPTION
## Summary
- allow clicking material slots for spool actions
- create spool usage dialog
- adjust styling for clickable material slots
- support spool service call

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails: rollup not found)*

------
https://chatgpt.com/codex/tasks/task_e_684713440dc48321be710864322c3acd