### PR TITLE
Set default options in spool dialog

### DIFF
--- a/src/templates/components/spool-usage-dialog.js
+++ b/src/templates/components/spool-usage-dialog.js
@@ -96,6 +96,7 @@ export const spoolUsageDialogTemplate = (dialogConfig, hass) => {
       <div class="dialog-content">
         <ha-select
           id="action-select"
+          .value="0"
           @selected=${handleSectionChange}
           @closed=${(e) => e.stopPropagation()}
         >
@@ -128,7 +129,7 @@ export const spoolUsageDialogTemplate = (dialogConfig, hass) => {
             `
           : html`
               <div class="section-content">
-                <ha-select id="spool-select">
+                <ha-select id="spool-select" .value=${spoolOptions[0]?.id ?? ''}>
                   ${spoolOptions.map(opt => html`<mwc-list-item .value=${opt.id}>${opt.name}</mwc-list-item>`)}
                 </ha-select>
               </div>


### PR DESCRIPTION
## Summary
- ensure `action-select` starts with the first option selected
- select the first spool when choosing a spool

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_685071db4c588321a73c46dc47b8b8cf