### PR TITLE
Add unassigned spool section

### DIFF
--- a/src/components/printwatch-card.js
+++ b/src/components/printwatch-card.js
@@ -3,7 +3,7 @@ import { LitElement, html } from 'lit';
 import { cardTemplate } from '../templates/card-template';
 import { cardStyles } from '../styles/card-styles';
 import { formatDuration, formatEndTime } from '../utils/formatters';
-import { isPrinting, isPaused, getAmsSlots, getEntityStates } from '../utils/state-helpers';
+import { isPrinting, isPaused, getAmsSlots, getUnassignedSpools, getEntityStates } from '../utils/state-helpers';
 import { DEFAULT_CONFIG, DEFAULT_CAMERA_REFRESH_RATE, DEFAULT_EX_CAMERA_REFRESH_RATE } from '../constants/config';
 import { localize } from '../utils/localize';
 import { CameraManager } from '../utils/camera-manager';
@@ -172,6 +172,7 @@ class PrintWatchCard extends LitElement {
 
     const entities = getEntityStates(this.hass, this.config);
     const amsSlots = getAmsSlots(this.hass, this.config);
+    const otherSpools = getUnassignedSpools(this.hass);
     
     const setDialogConfig = (config) => {
       this._dialogConfig = config;
@@ -196,6 +197,7 @@ class PrintWatchCard extends LitElement {
       entities,
       hass: this.hass,
       amsSlots,
+      otherSpools,
       formatters: this.formatters,
       _toggleLight: () => this._toggleLight(),
       _toggleFan: () => this._toggleFan(),

--- a/src/templates/card-template.js
+++ b/src/templates/card-template.js
@@ -12,8 +12,9 @@ import { spoolUsageDialogTemplate } from './components/spool-usage-dialog';
 export const cardTemplate = (context) => {
   const { 
     entities, 
-    hass, 
-    amsSlots, 
+    hass,
+    amsSlots,
+    otherSpools,
     _toggleLight, 
     _toggleFan, 
     cameraProps,
@@ -50,6 +51,7 @@ export const cardTemplate = (context) => {
       })}
       ${temperatureDisplayTemplate(entities, hass, dialogConfig, setDialogConfig)}
       ${materialSlotsTemplate(amsSlots, (slot, idx) => handleSpoolDialog(slot, idx))}
+      ${materialSlotsTemplate(otherSpools, (slot) => handleSpoolDialog(slot))}
       ${temperatureDialogTemplate(dialogConfig, hass)}
       ${spoolUsageDialogTemplate(spoolDialog, hass)}
       ${confirmDialogTemplate(confirmDialog)}


### PR DESCRIPTION
## Summary
- gather spoolman sensors without AMS trays
- expose them in printwatch card
- render extra spool section below AMS slots

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm run build` *(fails: rollup not found)*

------
https://chatgpt.com/codex/tasks/task_e_685efc7fbd9883218f73c83f29382a63