### PR TITLE
Add divider line after materials slots

### DIFF
--- a/src/styles/card-styles.js
+++ b/src/styles/card-styles.js
@@ -360,6 +360,19 @@ export const cardStyles = css`
     grid-template-columns: repeat(auto-fit, minmax(60px, 1fr));
     gap: 16px;
     padding: 16px;
+    margin-bottom: 32px;
+    padding-bottom: 32px;
+    position: relative;
+  }
+
+  .materials::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 20%;
+    right: 20%;
+    height: 1px;
+    background-color: var(--divider-color);
   }
 
   .material-slot {


### PR DESCRIPTION
## Summary
- show bottom divider under the material slots section

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_685f0248f2fc832194bdb61b4dae49b7