### PR TITLE
Simplify spool dialog and slot click behaviour

### DIFF
--- a/src/styles/card-styles.js
+++ b/src/styles/card-styles.js
@@ -381,11 +381,15 @@ export const cardStyles = css`
     align-items: center;
     gap: 8px;
     text-align: center;
-    cursor: pointer;
+    cursor: default;
     padding: 12px;
     border-radius: 12px;
     transition: background-color 0.2s ease;
     -webkit-tap-highlight-color: transparent;
+  }
+
+  .material-slot.clickable {
+    cursor: pointer;
   }
     
   .material-slot:hover {

--- a/src/templates/components/material-slots.js
+++ b/src/templates/components/material-slots.js
@@ -9,7 +9,9 @@ export const materialSlotsTemplate = (slots, onClick) => html`
       // Clip top 'percent%' of the fill only
       const clipInset = `inset(${percent}% 0 0 0)`;
       return html`
-        <div class="material-slot" @click=${() => onClick?.(slot, index)}>
+        <div
+          class="material-slot${slot.spool_id ? ' clickable' : ''}"
+          @click=${() => slot.spool_id && onClick?.(slot, index)}>
           <div class="material-circle-wrapper">
             <!-- Border layer: full circle -->
             <div

--- a/src/templates/components/spool-usage-dialog.js
+++ b/src/templates/components/spool-usage-dialog.js
@@ -2,7 +2,7 @@ import { html } from 'lit';
 import { localize } from '../../utils/localize';
 
 export const spoolUsageDialogTemplate = (dialogConfig, hass) => {
-  if (!dialogConfig?.open) return html``;
+  if (!dialogConfig?.open || !dialogConfig?.spoolId) return html``;
 
   const clearTray = (tray) => {
     Object.entries(hass.states).forEach(([entityId, stateObj]) => {
@@ -28,42 +28,28 @@ export const spoolUsageDialogTemplate = (dialogConfig, hass) => {
     const activeIndex = parseInt(select?.value ?? '0', 10);
     console.log('running submit', activeIndex);
 
-    if (dialogConfig.spoolId) {
-      if (activeIndex === 0) {
-        const input = dialog.querySelector('ha-textfield');
-        const value = input ? parseFloat(input.value) : null;
-        if (value === null || isNaN(value)) return;
-        hass.callService('spoolman', 'use_spool_filament', {
-          id: dialogConfig.spoolId,
-          use_weight: value
-        }).then(() => dialogConfig.onClose()).catch(err => {
-          console.error('Error using filament:', err);
-        });
-      } else if (activeIndex === 1) {
-        const select = dialog.querySelector('#tray-select');
-        const tray = parseInt(select?.value, 10);
-        if (!isNaN(tray)) {
-          clearTray(tray);
-          hass.callService('spoolman', 'patch_spool', {
-            id: dialogConfig.spoolId,
-            extra: { extra_ams_tray: tray }
-          }).then(() => dialogConfig.onClose()).catch(err => {
-            console.error('Error setting tray:', err);
-          });
-        }
-      }
-    } else {
-      const select = dialog.querySelector('#spool-select');
-      const spoolId = select?.value;
-      if (!spoolId) return;
-      const tray = dialogConfig.trayIndex + 1;
-      clearTray(tray);
-      hass.callService('spoolman', 'patch_spool', {
-        id: spoolId,
-        extra: { extra_ams_tray: tray }
+    if (activeIndex === 0) {
+      const input = dialog.querySelector('ha-textfield');
+      const value = input ? parseFloat(input.value) : null;
+      if (value === null || isNaN(value)) return;
+      hass.callService('spoolman', 'use_spool_filament', {
+        id: dialogConfig.spoolId,
+        use_weight: value
       }).then(() => dialogConfig.onClose()).catch(err => {
-        console.error('Error selecting spool:', err);
+        console.error('Error using filament:', err);
       });
+    } else if (activeIndex === 1) {
+      const select = dialog.querySelector('#tray-select');
+      const tray = parseInt(select?.value, 10);
+      if (!isNaN(tray)) {
+        clearTray(tray);
+        hass.callService('spoolman', 'patch_spool', {
+          id: dialogConfig.spoolId,
+          extra: { extra_ams_tray: tray }
+        }).then(() => dialogConfig.onClose()).catch(err => {
+          console.error('Error setting tray:', err);
+        });
+      }
     }
   };
 
@@ -77,15 +63,6 @@ export const spoolUsageDialogTemplate = (dialogConfig, hass) => {
     });
     e.stopPropagation();
   };
-
-  const spoolSensors = Object.entries(hass.states)
-    .filter(([eid]) => eid.startsWith('sensor.spoolman_spool_'))
-    .map(([, s]) => s);
-
-  const spoolOptions = spoolSensors.map(s => ({
-    id: s.attributes.id,
-    name: s.attributes.name || s.attributes.display_name || `Spool ${s.attributes.id}`
-  }));
 
   const currentTray = dialogConfig.trayIndex + 1;
 
@@ -103,40 +80,26 @@ export const spoolUsageDialogTemplate = (dialogConfig, hass) => {
           @selected=${handleSectionChange}
           @closed=${(e) => e.stopPropagation()}
         >
-          ${dialogConfig.spoolId
-            ? html`
-                <mwc-list-item value="0">
-                  ${localize.t('materials.use_filament')}
-                </mwc-list-item>
-                <mwc-list-item value="1">
-                  ${localize.t('materials.set_tray')}
-                </mwc-list-item>
-              `
-            : html`<mwc-list-item value="0">${localize.t('materials.select_spool')}</mwc-list-item>`}
+          <mwc-list-item value="0">
+            ${localize.t('materials.use_filament')}
+          </mwc-list-item>
+          <mwc-list-item value="1">
+            ${localize.t('materials.set_tray')}
+          </mwc-list-item>
         </ha-select>
-        ${dialogConfig.spoolId
-          ? html`
-              <div class="section-content">
-                <ha-textfield
-                  label=${localize.t('materials.enter_weight')}
-                  type="number"
-                  class="temp-input"
-                ></ha-textfield>
-              </div>
-              <div class="section-content" style="display:none">
-                <div class="current-tray">${localize.t('materials.current_tray')}: ${currentTray}</div>
-                <ha-select id="tray-select" .value="${currentTray}">
-                  ${[1, 2, 3, 4].map(i => html`<mwc-list-item .value=${i}>${i}</mwc-list-item>`)}
-                </ha-select>
-              </div>
-            `
-          : html`
-              <div class="section-content">
-                <ha-select id="spool-select" .value=${spoolOptions[0]?.id ?? ''}>
-                  ${spoolOptions.map(opt => html`<mwc-list-item .value=${opt.id}>${opt.name}</mwc-list-item>`)}
-                </ha-select>
-              </div>
-            `}
+        <div class="section-content">
+          <ha-textfield
+            label=${localize.t('materials.enter_weight')}
+            type="number"
+            class="temp-input"
+          ></ha-textfield>
+        </div>
+        <div class="section-content" style="display:none">
+          <div class="current-tray">${localize.t('materials.current_tray')}: ${currentTray}</div>
+          <ha-select id="tray-select" .value="${currentTray}">
+            ${[1, 2, 3, 4].map(i => html`<mwc-list-item .value=${i}>${i}</mwc-list-item>`)}
+          </ha-select>
+        </div>
       </div>
       <mwc-button
         slot="secondaryAction"


### PR DESCRIPTION
## Summary
- simplify spool usage dialog to only support `use filament` and `set tray`
- make material slots clickable only when associated with a Spoolman spool
- adjust styles for clickable material slots

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_685f03efe13483218e43a6350325f871