### PR TITLE
Add spoolman control buttons

### DIFF
--- a/src/components/printwatch-card.js
+++ b/src/components/printwatch-card.js
@@ -198,6 +198,7 @@ class PrintWatchCard extends LitElement {
       hass: this.hass,
       amsSlots,
       otherSpools,
+      config: this.config,
       formatters: this.formatters,
       _toggleLight: () => this._toggleLight(),
       _toggleFan: () => this._toggleFan(),

--- a/src/constants/config.js
+++ b/src/constants/config.js
@@ -29,7 +29,10 @@ export const DEFAULT_CONFIG = {
   chamber_light_entity: 'light.p1s_01p00a382500072_chamber_light',
   online_entity: 'binary_sensor.p1s_01p00a382500072_online',
   print_weight_entity: 'sensor.p1s_print_weight',
-  print_length_entity: 'sensor.p1s_print_length'
+  print_length_entity: 'sensor.p1s_print_length',
+  refresh_printer_button_entity: 'button.a1_force_refresh_data',
+  refresh_spoolman_script: 'script.reload_spoolman',
+  spoolman_url: 'http://192.168.129.70:7912/'
 };
 
 /**

--- a/src/styles/card-styles.js
+++ b/src/styles/card-styles.js
@@ -436,4 +436,11 @@ export const cardStyles = css`
     font-size: 12px;
     color: var(--secondary-text-color);
   }
+  .spoolman-buttons {
+    display: flex;
+    justify-content: space-around;
+    gap: 8px;
+    padding: 16px;
+  }
+
 `;

--- a/src/templates/card-template.js
+++ b/src/templates/card-template.js
@@ -8,13 +8,15 @@ import { materialSlotsTemplate } from './components/material-slots';
 import { temperatureDialogTemplate } from './components/temperature-controls';
 import { confirmDialogTemplate } from './components/confirm-dialog';
 import { spoolUsageDialogTemplate } from './components/spool-usage-dialog';
+import { spoolmanButtonsTemplate } from './components/spoolman-buttons';
 
 export const cardTemplate = (context) => {
-  const { 
-    entities, 
+  const {
+    entities,
     hass,
     amsSlots,
     otherSpools,
+    config,
     _toggleLight, 
     _toggleFan, 
     cameraProps,
@@ -52,6 +54,7 @@ export const cardTemplate = (context) => {
       ${temperatureDisplayTemplate(entities, hass, dialogConfig, setDialogConfig)}
       ${materialSlotsTemplate(amsSlots, (slot, idx) => handleSpoolDialog(slot, idx))}
       ${materialSlotsTemplate(otherSpools, (slot) => handleSpoolDialog(slot))}
+      ${spoolmanButtonsTemplate({ hass, config })}
       ${temperatureDialogTemplate(dialogConfig, hass)}
       ${spoolUsageDialogTemplate(spoolDialog, hass)}
       ${confirmDialogTemplate(confirmDialog)}

--- a/src/templates/components/spoolman-buttons.js
+++ b/src/templates/components/spoolman-buttons.js
@@ -1,0 +1,42 @@
+import { html } from 'lit';
+import { localize } from '../../utils/localize';
+
+export const spoolmanButtonsTemplate = ({ hass, config }) => {
+  if (!hass || !config) return html``;
+
+  const refreshButton = config.refresh_printer_button_entity;
+  const spoolmanScript = config.refresh_spoolman_script;
+  const spoolmanUrl = config.spoolman_url;
+
+  const pressButton = () => {
+    if (refreshButton) {
+      hass.callService('button', 'press', { entity_id: refreshButton });
+    }
+  };
+
+  const runScript = () => {
+    if (spoolmanScript) {
+      hass.callService('script', 'turn_on', { entity_id: spoolmanScript });
+    }
+  };
+
+  const openLink = () => {
+    if (spoolmanUrl) {
+      window.open(spoolmanUrl, '_blank');
+    }
+  };
+
+  return html`
+    <div class="spoolman-buttons">
+      <button class="btn" @click=${pressButton}>
+        ${localize.t('controls.refresh_printer')}
+      </button>
+      <button class="btn" @click=${runScript}>
+        ${localize.t('controls.refresh_spoolman')}
+      </button>
+      <button class="btn" @click=${openLink}>
+        ${localize.t('controls.go_to_spoolman')}
+      </button>
+    </div>
+  `;
+};

--- a/src/translations/de.json
+++ b/src/translations/de.json
@@ -40,7 +40,10 @@
           "pause": "Pause",
           "resume": "Fortsetzen",
           "stop": "Stopp",
-          "cancel": "Abbrechen"
+          "cancel": "Abbrechen",
+          "refresh_printer": "Drucker aktualisieren",
+          "refresh_spoolman": "Spoolman neu laden",
+          "go_to_spoolman": "Zu Spoolman"
         },
         "dialogs": {
           "pause": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -56,7 +56,10 @@
           "save": "Save",
           "submit": "Submit",
           "internal": "Internal",
-          "external": "External"
+          "external": "External",
+          "refresh_printer": "Refresh Printer",
+          "refresh_spoolman": "Refresh Spoolman",
+          "go_to_spoolman": "Go to Spoolman"
         },
         "speed_profiles": {
           "silent": "Silent",


### PR DESCRIPTION
## Summary
- add a new component for Spoolman buttons
- display buttons after unassigned spools in card template
- pass card config through to templates
- include defaults for new buttons in config
- translate button labels in English and German
- add simple styles for new button row

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm run build` *(fails: rollup not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f0a0b11648321809ae3531c1d19a1