### PR TITLE
Set placeholder spoolman_url

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Spoolman integration of printwatch-card and external camera.
 - Hook an external camera to feed. Switch between internal and external.
 - See the weight of every spoolman spool. Visualize used percentage of the spool.
 - Use Filament, Set Filament Amount and Set Tray from the card.
+- Set `spoolman_url` to the address of your Spoolman instance. The default
+  `http://localhost:7912/` is a placeholder and must be overridden.
 
 In your spoolman, you need an extra field called ams_tray. 0 means its not on ams. 1+ means its on that slot of the ams.
 

--- a/src/constants/config.js
+++ b/src/constants/config.js
@@ -38,7 +38,9 @@ export const DEFAULT_CONFIG = {
   print_length_entity: 'sensor.p1s_print_length',
   refresh_printer_button_entity: 'button.a1_force_refresh_data',
   refresh_spoolman_script: 'script.reload_spoolman',
-  spoolman_url: 'http://192.168.129.70:7912/',
+  // URL of your Spoolman instance. The default is a placeholder and
+  // should be overridden in your card configuration.
+  spoolman_url: 'http://localhost:7912/',
   camera_refresh_rate: DEFAULT_CAMERA_REFRESH_RATE,
   external_camera_refresh_rate: DEFAULT_EX_CAMERA_REFRESH_RATE
 };


### PR DESCRIPTION
## Summary
- use `http://localhost:7912/` as the default `spoolman_url`
- mention that this value must be overridden in README

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config file)*

------
https://chatgpt.com/codex/tasks/task_e_685fdd47cb84832191e66299124986de