### PR TITLE
Update README with setup steps and config info

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,32 @@ In your spoolman, you need an extra field called ams_tray. 0 means its not on am
 ![PrintWatch Card Screenshot](assets/printwatch-spoolman2.png)
 ![PrintWatch Card Screenshot](assets/printwatch-spoolman3.png)
 ![PrintWatch Card Screenshot](assets/printwatch-spoolman4.png)
+
+## Installation
+
+1. Install dependencies and build the card:
+   ```bash
+   npm install
+   npm run build
+   ```
+   This generates `dist/printwatch-card.js`.
+
+2. Copy the file to your Home Assistant `www` folder and add it as a resource:
+   ```yaml
+   resources:
+     - url: /local/printwatch-card.js
+       type: module
+   ```
+
+## Configuration
+
+Add the card to your Lovelace dashboard. `spoolman_url` specifies the URL of your Spoolman instance and is used by the quick link button.
+
+```yaml
+type: custom:printwatch-card
+printer_name: My 3D Printer
+spoolman_url: http://192.168.1.50:7912/
+camera_entity: image.p1s_camera
+```
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on how to help with the project. Licensed under the [MIT License](LISCENSE).


### PR DESCRIPTION
## Summary
- document npm build steps and Home Assistant setup
- show how to configure `spoolman_url`
- link to contribution guide and license

## Testing
- `npm run lint` *(fails: couldn't find a configuration file)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685fdd35d3e0832182717a350d81c750